### PR TITLE
fix error if max new tokens out of block size during inference

### DIFF
--- a/nano-gpt-base/Head.cs
+++ b/nano-gpt-base/Head.cs
@@ -48,7 +48,7 @@ namespace TransformerHead
             register_module("value", _value);
 
             // Lower triangular mask to ensure causality in self-attention
-            _tril = torch.tril(torch.ones(Settings.BlockSize, Settings.BlockSize));
+            _tril = torch.tril(torch.ones(Settings.BlockSize, Settings.BlockSize)); //? it should be TxT dynamically for inference.
             register_buffer("tril", _tril);
 
             // Dropout layer for regularization.


### PR DESCRIPTION
When inferencing with nanoGPT, the fixed weight mask (block_size x block_size) causes errors if user-specified max new tokens exceeds block_size, which makes T > block_size. 

Fixed by sliding a ctx window of the same length as the block size, like in [nanoGPT](https://github.com/karpathy/nanoGPT/blob/93a43d9a5c22450bbf06e78da2cb6eeef084b717/model.py#L314).

or consider creating dynamic masks like this [gpt-2](https://github.com/openai/gpt-2/blob/9b63575ef42771a015060c964af2c3da4cf7c8ab/src/model.py#L83) so the model can see full context.